### PR TITLE
Use nib in all files.

### DIFF
--- a/client.src/core/assets/styl/index.styl
+++ b/client.src/core/assets/styl/index.styl
@@ -1,5 +1,4 @@
 // External libs
-@import 'nib'
 @import 'html5-reset/assets/css/reset.css'
 @import 'octicons'
 @import 'entypo'

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
     stylus: {
       options: {
         'include css': true,
-        import: ['variables'],
+        import: ['variables', 'nib'],
         paths: ['bower_components']
       },
       dev: {


### PR DESCRIPTION
This commit uses nib for all stylus files, which does nice things like autoprefix flex-box.
