### PR TITLE
Re-enable buttons when HTTP requests fail.

### DIFF
--- a/client.src/shared/views/existing-menu/index.js
+++ b/client.src/shared/views/existing-menu/index.js
@@ -32,6 +32,11 @@ export default mn.ItemView.extend({
 
   initialize: function(options) {
     this.mergeOptions(options, this.existingMenuOptions);
+    this.on({
+      'save save:fail': '_resetSaveBtn',
+      'delete delete:fail': '_resetDeleteBtn',
+      'fork:fail': '_resetForkBtn'
+    }, this);
   },
 
   onRender: function() {
@@ -49,26 +54,12 @@ export default mn.ItemView.extend({
     }
   },
 
-  onClickFork: function() {
-    this.ui.fork
-      .html('Forking...')
-      .prop('disabled', true);
-  },
-
   onClickSave: function() {
     this._cachedSaveHtml = this.ui.save.html();
     this.ui.save
       .width(this.ui.save.width())
       .html('Saving...')
       .prop('disabled', true);
-  },
-
-  onSave: function() {
-    this.ui.save
-      .width('auto')
-      .html(this._cachedSaveHtml)
-      .prop('disabled', false);
-    this._cachedSaveHtml = null;
   },
 
   onClickDelete: function() {
@@ -81,10 +72,32 @@ export default mn.ItemView.extend({
     }
   },
 
-  onDelete: function() {
+  onClickFork: function() {
+    this._cachedForkHtml = this.ui.fork.html();
+    this.ui.fork
+      .html('Forking...')
+      .prop('disabled', true);
+  },
+
+  _resetSaveBtn: function() {
+    this.ui.save
+      .width('auto')
+      .html(this._cachedSaveHtml)
+      .prop('disabled', false);
+    this._cachedSaveHtml = null;
+  },
+
+  _resetDeleteBtn: function() {
     this.ui.delete
       .html(this._cachedDeleteHtml)
       .prop('disabled', false);
     this._cachedDeleteHtml = null;
+  },
+
+  _resetForkBtn: function() {
+    this.ui.fork
+      .html(this._cachedForkHtml)
+      .prop('disabled', false);
+    this._cachedForkHtml = null;
   }
 });

--- a/client.src/shared/views/gist-view/index.js
+++ b/client.src/shared/views/gist-view/index.js
@@ -68,11 +68,12 @@ export default mn.LayoutView.extend({
   _fork: function() {
     var baseUrl = githubApiHelpers.url + '/gists';
     var oldDescription = this.model.get('description');
+    var self = this;
 
     // First, we fork the old Gist
     bb.$.post(baseUrl + '/' + this.model.get('id') + '/forks')
 
-    // Now we need to update the Gist's description
+      // Now we need to update the Gist's description
       .then(function(resp) {
         return bb.$.ajax({
           type: 'PATCH',
@@ -81,8 +82,11 @@ export default mn.LayoutView.extend({
         });
       })
 
-    // Lastly, we redirect to the newly created fork
-      .then(this._onForkComplete);
+      // Lastly, we redirect to the newly created fork
+      .then(this._onForkComplete)
+      .fail(function() {
+        self.menu.trigger('fork:fail');
+      });
   },
 
   _onForkComplete: function(resp) {
@@ -98,7 +102,7 @@ export default mn.LayoutView.extend({
         routerChannel.command('navigate', Radio.request('user', 'user').get('login'));
       })
       .catch(function() {
-        console.log('Unable to delete the gist');
+        self.menu.trigger('delete:fail');
       });
   },
 
@@ -127,7 +131,7 @@ export default mn.LayoutView.extend({
     var self = this;
     this.model.save(attrs, saveOptions)
       .then(function(gistData) {
-        self.menu.triggerMethod('save');
+        self.menu.trigger('save');
         if (isNew) {
           var username = gistData.owner ? gistData.owner.login : 'anonymous';
           var url = '/' + username + '/' + gistData.id;
@@ -135,6 +139,7 @@ export default mn.LayoutView.extend({
         }
       })
       .catch(function() {
+        self.menu.trigger('save:fail');
         console.log('Gist not saved', arguments);
       });
   },


### PR DESCRIPTION
Resolves #219.

At the moment a successful work won't cause a redirect. It updates the URL in the navbar, but the view won't swap.

To test: does saving/deleting change the view?

**Update**
The forking failure is a problem w. the already-existent Gistbook code. Ref #250.
