### PR TITLE
Remove regression in routing.

### DIFF
--- a/client.src/vendor/routing/router.js
+++ b/client.src/vendor/routing/router.js
@@ -13,9 +13,6 @@ export default BaseRouter.extend({
       throw new Error('A Route object must be associated with each route.');
     }
 
-    // Do nothing if it's the same route
-    if (newRoute === this.currentRoute) { return; }
-
     var redirect = _.result(newRoute, 'redirect');
     if (_.isString(redirect)) {
       this.navigate(redirect, {trigger:true});


### PR DESCRIPTION
In 5d5c885 I attempted to add a performance boost by not routing
when the same route was matched. This made it impossible to go from,
say, one user's Gistbook to another's directly, such as when forking.

Resolves #250
