### PR TITLE
Cache browserify-cdn resources

### DIFF
--- a/client.src/vendor/gistbook-view/managers/module-bundler.js
+++ b/client.src/vendor/gistbook-view/managers/module-bundler.js
@@ -4,34 +4,66 @@
 //
 
 import * as bb from 'backbone';
+import * as mn from 'marionette';
 import * as _ from 'underscore';
 import * as detective from 'detective';
+import * as createCache from 'browser-module-cache';
 
-export default {
+var cache = createCache({
+  name: 'browser-module-cache',
+  inMemory: false
+});
+
+var ModuleBundler = mn.Object.extend({
   getBundle: function(src) {
     var modules = detective(src);
 
     if (modules.length === 0) {
-      return Promise.resolve(src);
+      this.trigger('retrieve', src);
+      return;
     }
 
-    var dependencies = {};
+    var allBundles = '';
+    var downloads = [];
 
-    _.each(modules, function(module) {
-      dependencies[module] = 'latest';
-    });
+    var self = this;
+    cache.get(function(err, cached) {
+      if (err) { throw new Error(err); }
 
-    var body = {
-      options: { debug: true },
-      dependencies: dependencies
-    };
-
-    return bb.$.post('https://wzrd.bocoup.com/multi', JSON.stringify(body)).then(function(data) {
-      var js = '';
-      _.each(data, function(datum) {
-        js += datum.bundle;
+      _.each(modules, function(module) {
+        if (cached[module]) {
+          allBundles += cached[module].bundle;
+        } else {
+          downloads.push(module);
+        }
       });
-      return js + src;
+
+      // If everything is cached, then we return
+      // all of the cached source
+      if (!downloads.length) {
+        self.trigger('retrieve', allBundles + src);
+        return;
+      }
+
+      var dependencies = {};
+      _.each(downloads, function(module) {
+        dependencies[module] = 'latest';
+      });
+
+      var body = {
+        options: { debug: true },
+        dependencies: dependencies
+      };
+
+      return bb.$.post('https://wzrd.bocoup.com/multi', JSON.stringify(body)).then(function(data) {
+        _.each(data, function(datum) {
+          allBundles += datum.bundle;
+        });
+        cache.put(data, function() {});
+        self.trigger('retrieve', allBundles + src);
+      });
     });
   }
-};
+});
+
+export default new ModuleBundler();

--- a/client.src/vendor/gistbook-view/views/output-view/index.js
+++ b/client.src/vendor/gistbook-view/views/output-view/index.js
@@ -56,11 +56,11 @@ export default mn.LayoutView.extend({
     _.delay(_.bind(this._showSpinner, this), 250);
     var code = this.codeManager.getCode();
     var self = this;
-    moduleBundler.getBundle(code.javascript)
-      .then(function(js) {
-        code.javascript = js;
-        self.compiler.compile(code);
-      });
+    this.listenToOnce(moduleBundler, 'retrieve', function(js) {
+      code.javascript = js;
+      self.compiler.compile(code);
+    });
+    moduleBundler.getBundle(code.javascript);
   },
 
   _showSpinner: function() {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "backbone.radio": "^0.6.0",
     "backbone.wreqr": "^1.2.1",
     "body-parser": "^1.7.0",
+    "browser-module-cache": "^0.1.3",
     "cookies": "^0.4.1",
     "cookies-js": "^0.4.0",
     "detective": "^4.0.0",


### PR DESCRIPTION
This update caches browserify-cdn resources in localStorage, cutting back on requests to the API.

aka

shit's dope
