### PR TITLE
Adds sticky loader when transitioning pages.

### DIFF
--- a/client.src/core/assets/styl/scaffolding.styl
+++ b/client.src/core/assets/styl/scaffolding.styl
@@ -15,7 +15,8 @@ html
 // We use flex box to give us the 'sticky' footer
 body
   min-height 100%
-  min-width $appWidth + 40px
+  min-width $appWidth
+  // min-width $appWidth + 40px
   display flex
   flex-direction column
 

--- a/client.src/core/index.js
+++ b/client.src/core/index.js
@@ -27,6 +27,9 @@ dev.start();
 // Configure AJAX to look out for ETag and LastModified headers
 import './services/ajax-if-modified';
 
+// Load semantic ui
+import './services/semantic-ui';
+
 // Load & start our app
 import app from './app';
 app.start();

--- a/client.src/core/services/semantic-ui.js
+++ b/client.src/core/services/semantic-ui.js
@@ -1,0 +1,5 @@
+//
+// Load Semantic UI
+//
+
+import 'semantic/sticky';

--- a/client.src/shared/views/loading-view/index.js
+++ b/client.src/shared/views/loading-view/index.js
@@ -7,9 +7,15 @@
 import ItemView from 'base/item-view';
 
 var LoadingView = ItemView.extend({
-  template: false,
-
-  className: 'loading-view'
+  template: 'loadingView',
+  className: 'loading-view',
+  spinnerOptions: {
+    color: '#555',
+    lines: 7,
+    length: 10,
+    width: 5,
+    radius: 7
+  }
 });
 
 export default new LoadingView();

--- a/client.src/shared/views/loading-view/loading-view.jst
+++ b/client.src/shared/views/loading-view/loading-view.jst
@@ -1,0 +1,3 @@
+<div class='loader-container'>
+  <div class='ui loader active'></div>  
+</div>

--- a/client.src/shared/views/loading-view/loading-view.styl
+++ b/client.src/shared/views/loading-view/loading-view.styl
@@ -7,3 +7,7 @@
   opacity .7
   height 100%
   width 100%
+  
+  .loader-container
+    position relative
+    height 40px

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -186,7 +186,8 @@ module.exports = function(grunt) {
           loaders: [
             {test: /templates/, loader: 'imports?_=underscore!exports?this.JST'},
             {test: /\.js$/, exclude: /node_modules/, loader: '6to5-loader'},
-            {test: /package\.json/, loader: 'json-loader'}
+            {test: /package\.json/, loader: 'json-loader'},
+            {test: /semantic/, loader: 'imports?jQuery=jquery'}
           ]
         },
         resolve: {
@@ -194,7 +195,8 @@ module.exports = function(grunt) {
             marionette: 'backbone.marionette',
             'backbone.wreqr': 'backbone.radio',
             radio: 'backbone.radio',
-            _: 'underscore'
+            _: 'underscore',
+            semantic: 'semantic-ui/src/definitions/modules'
           },
           modulesDirectories: ['node_modules', '<%= app.tmp %>', '<%= app.src %>']
         },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "json-loader": "^0.5.1",
     "marked": "^0.3.2",
     "octonode": "^0.6.2",
+    "semantic-ui": "^1.1.2",
     "sortable": "git://github.com/jmeas/Sortable.git#optional-set-text",
     "spin.js": "^2.0.1",
     "underscore": "1.6.0"

--- a/server/views/layouts/main.hbs
+++ b/server/views/layouts/main.hbs
@@ -6,6 +6,7 @@
   <title>Gistbook</title>
   <link rel="shortcut icon" href="/favicon.ico" />
   <link rel='stylesheet' href='/style.css'>
+  {{> semantic-ui-css }}
   {{> livereload-config }}
 </head>
 <body>

--- a/server/views/partials/semantic-ui-css.hbs
+++ b/server/views/partials/semantic-ui-css.hbs
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.1.2/components/sticky.min.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.1.2/components/loader.min.css">


### PR DESCRIPTION
Resolves #272 

Todo:
- [x] Figure out why the loader moves over a few pixels on Chrome
- [ ] Browser test

Answer to 1:

It likely moves over because the body's min-width no longer pushes it those few pixels over. When the browser window is < the size of Gistbook's width, it will do the shift. Removing the min-width fixes the problem.
